### PR TITLE
组件样式污染到全局了

### DIFF
--- a/src/components/navbar_lxy/index.scss
+++ b/src/components/navbar_lxy/index.scss
@@ -1,11 +1,13 @@
-view,
-text,
-scroll-view,
-input,
-button,
-image,
-cover-view {
-  box-sizing: border-box;
+.lxy-nav-bar {
+  view,
+  text,
+  scroll-view,
+  input,
+  button,
+  image,
+  cover-view {
+    box-sizing: border-box;
+  }
 }
 page {
   /* prettier-ignore */


### PR DESCRIPTION
`·box-sizing: border-box;` 并不是所有标签都需要的默认配置，这将可能导致页面样式出现无法预知的情况。